### PR TITLE
Use secret key from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,30 @@
 # gooddollar-oracle
 GoodDollar oracle for SBT issuer.
 
+## Configuration
+
+All default configuration is available in `default.json` config file. To override these settings a config file `local.jsom` could
+be used instead.
+
+### Credentials
+
+Use `near generate-key i-am-human-credentials --networkId mainnet` to generate new credentials.
+The above command will create a file `~/.near-credentials/mainnet/i-am-human-credentials.json` with required secret key.
+
+The `private_key` property from a resulting file could be either passed with environment variable `SECKEY` or set via configuration file as:
+
+```
+  "signer": {
+    "credentials": {
+      "seckey": "{{PUT_SECRET_KEY_HERE}}"
+    }
+  }
+```
+
+The public key generated in a file `~/.near-credentials/mainnet/i-am-human-credentials.json` is in wrapped format.
+If the ed25519 base64 encoded public key required (e.g. for i-am-human near contract), it could be obtained after service start from
+an output (search for text `ED25519 public key (base64 encoded):`)
+
 ## Docker
 
 Build docker image

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ be used instead.
 Use `near generate-key i-am-human-credentials --networkId mainnet` to generate new credentials.
 The above command will create a file `~/.near-credentials/mainnet/i-am-human-credentials.json` with required secret key.
 
-The `private_key` property from a resulting file could be either passed with environment variable `SECKEY` or set via configuration file as:
+The `private_key` property from a resulting file could be either passed with environment variable `SIGNING_KEY` or set via configuration file as:
 
 ```
   "signer": {

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ be used instead.
 ### Credentials
 
 Use `near generate-key i-am-human-credentials --networkId mainnet` to generate new credentials.
-The above command will create a file `~/.near-credentials/mainnet/i-am-human-credentials.json` with required secret key.
+The above command will create a file `~/.near-credentials/mainnet/i-am-human-credentials.json` with required private key.
 
 The `private_key` property from a resulting file could be either passed with environment variable `SIGNING_KEY` or set via configuration file as:
 
 ```
   "signer": {
     "credentials": {
-      "seckey": "{{PUT_SECRET_KEY_HERE}}"
+      "signingKey": "{{PUT_PRIVATE_KEY_HERE}}"
     }
   }
 ```

--- a/config/default.json
+++ b/config/default.json
@@ -4,9 +4,6 @@
       "url": "https://rpc.fuse.io/" 
   },
   "signer": {
-      "credentials": {
-          "seckey": "",
-          "pubkey": ""
-      }
+    "credentials": null
   }
 }

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -22,14 +22,14 @@ impl<'de> Deserialize<'de> for SignerCredentials {
         let properties: std::collections::HashMap<String, String> =
             Deserialize::deserialize(deserializer).unwrap_or_default();
 
-        let raw_seckey = match std::env::var("SECKEY") {
+        let raw_seckey = match std::env::var("SIGNING_KEY") {
           Err(VarError::NotPresent) => properties.get("seckey").cloned(),
           Err(VarError::NotUnicode(invalid_data)) => {
-              return Err(de::Error::custom(format!("Invalid SECKEY {:?}", invalid_data)))
+              return Err(de::Error::custom(format!("Invalid SIGNING_KEY {:?}", invalid_data)))
           },
           Ok(value) => Some(value),
         }.ok_or_else(|| {
-            D::Error::custom("Secret key should be provided either with SECKEY env variable or within configuration file")
+            D::Error::custom("Secret key should be provided either with SIGNING_KEY env variable or within configuration file")
         })?;
 
         let seckey = SecretKey::from_str(&raw_seckey).map_err(|e| {

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -1,5 +1,7 @@
-use near_crypto::{PublicKey, SecretKey};
+use near_crypto::SecretKey;
+use near_sdk::serde::de::{self, Error};
 use near_sdk::serde::Deserialize;
+use std::{env::VarError, str::FromStr};
 
 #[derive(Deserialize, Debug, Clone)]
 #[serde(crate = "near_sdk::serde", rename_all = "camelCase")]
@@ -7,17 +9,43 @@ pub struct SignerConfig {
     pub credentials: SignerCredentials,
 }
 
-#[derive(Deserialize, Debug, Clone)]
-#[serde(crate = "near_sdk::serde")]
+#[derive(Debug, Clone)]
 pub struct SignerCredentials {
     pub seckey: SecretKey,
-    pub pubkey: PublicKey,
 }
 
-#[cfg(test)]
-pub fn generate_keys() -> (SecretKey, PublicKey) {
-    let seckey = SecretKey::from_random(near_crypto::KeyType::ED25519);
-    let pubkey = seckey.public_key();
+impl<'de> Deserialize<'de> for SignerCredentials {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: de::Deserializer<'de>,
+    {
+        let properties: std::collections::HashMap<String, String> =
+            Deserialize::deserialize(deserializer).unwrap_or_default();
 
-    (seckey, pubkey)
+        let raw_seckey = match std::env::var("SECKEY") {
+          Err(VarError::NotPresent) => properties.get("seckey").cloned(),
+          Err(VarError::NotUnicode(invalid_data)) => {
+              return Err(de::Error::custom(format!("Invalid SECKEY {:?}", invalid_data)))
+          },
+          Ok(value) => Some(value),
+        }.ok_or_else(|| {
+            D::Error::custom("Secret key should be provided either with SECKEY env variable or within configuration file")
+        })?;
+
+        let seckey = SecretKey::from_str(&raw_seckey).map_err(|e| {
+            de::Error::custom(format!("Secret key deserialization failure. Error {e}"))
+        })?;
+
+        if !verify_secret_key(&seckey) {
+            return Err(de::Error::custom("Secret key is incorrect"));
+        }
+
+        Ok(Self { seckey })
+    }
+}
+
+fn verify_secret_key(seckey: &SecretKey) -> bool {
+    let verification_data = "verify".as_bytes();
+    let sig = seckey.sign(verification_data);
+    sig.verify(verification_data, &seckey.public_key())
 }


### PR DESCRIPTION
## Notes

### Changed

- Allow `signingKey` to be passed via `SIGNING_KEY` env var
- Update README with instructions for credentials section of config

### Removed

- Remove `pubkey` from configuration file. Obtain it from `signingKey` instead
